### PR TITLE
Fix error that the Download Directory not exists

### DIFF
--- a/Bili-dl/Bili-dl/BiliDownload/DownloadQueue.xaml.cs
+++ b/Bili-dl/Bili-dl/BiliDownload/DownloadQueue.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using ConfigUtil;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -70,6 +71,10 @@ namespace BiliDownload
 
         private void OpenDownloadDirectoryBtn_Click(object sender, RoutedEventArgs e)
         {
+            if (!Directory.Exists(ConfigManager.GetSettings().DownloadPath))
+            {
+                Directory.CreateDirectory(ConfigManager.GetSettings().DownloadPath);
+            }
             System.Diagnostics.Process.Start(string.Format("\"{0}\"", ConfigManager.GetSettings().DownloadPath + "\\"));
         }
 


### PR DESCRIPTION
修复第一次启动时，视频文件夹内，无Bili-dl文件夹时，打开目录报错的问题